### PR TITLE
Resolve method signature and type mismatches

### DIFF
--- a/src/diarization/pyannote.rs
+++ b/src/diarization/pyannote.rs
@@ -29,9 +29,8 @@ impl DiarizationBackend for PyannoteIntegration {
         }])
     }
 
-    fn embed_speaker(&self, audio: &[f32]) -> Vec<f32> {
-        let i16_data: Vec<i16> = audio.iter().map(|&f| (f * i16::MAX as f32) as i16).collect();
-        self.extractor.extract(&i16_data, self.sample_rate)
+    fn embed_speaker(&self, audio: &[i16]) -> Vec<f32> {
+        self.extractor.extract_i16(audio, self.sample_rate)
             .unwrap_or_default()
     }
 }

--- a/src/transcription/whisper_integration.rs
+++ b/src/transcription/whisper_integration.rs
@@ -25,7 +25,7 @@ impl WhisperIntegration {
 impl TranscriptionBackend for WhisperIntegration {
     fn transcribe_audio(&mut self, audio: &[f32], sample_rate: u32) -> Result<String, Box<dyn std::error::Error>> {
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        params.set_sample_rate(sample_rate as f32);
+        params.to_sample_rate(sample_rate as f32);
 
         self.state.full(params, audio)?;
         let num_segments = self.state.full_n_segments()?;


### PR DESCRIPTION
Resolve type mismatches and method errors in `pyannote.rs`, `loopback_capture.rs`, and `whisper_integration.rs`.

* **`src/diarization/pyannote.rs`**
  - Change the parameter type of `embed_speaker` method from `&[f32]` to `&[i16]`.
  - Replace the call to `self.extractor.extract` with `self.extractor.extract_i16`.

* **`src/audio/loopback_capture.rs`**
  - Change the type of `buffer` from `Vec<f32>` to `Vec<i16>`.
  - Change the type of `float_samples` from `Vec<f32>` to `Vec<i16>`.
  - Update the call to `diar.embed_speaker` to use `segment.samples` directly.
  - Adjust the sample format handling to convert data to `i16`.

* **`src/transcription/whisper_integration.rs`**
  - Replace the call to `params.set_sample_rate` with `params.to_sample_rate`.

